### PR TITLE
Enable prometheus endpoint

### DIFF
--- a/firmware/dcbuddy.yml
+++ b/firmware/dcbuddy.yml
@@ -53,6 +53,8 @@ wifi:
     ssid: "DCBuddy Fallback Hotspot"
     password: "password"
 
+prometheus:
+
 web_server:
   port: 80
   log: False

--- a/firmware/dcbuddy.yml
+++ b/firmware/dcbuddy.yml
@@ -58,6 +58,7 @@ prometheus:
 web_server:
   port: 80
   log: False
+  version: 3
 
 improv_serial:
 


### PR DESCRIPTION
As it says on the tin - this will enable /metrics as an endpoint. 